### PR TITLE
Raise Pubid::Core::Errors::ParseError instead of Pubid::Ieee::Errors::ParseError

### DIFF
--- a/lib/pubid/ieee/errors.rb
+++ b/lib/pubid/ieee/errors.rb
@@ -1,6 +1,5 @@
 module Pubid::Ieee
   module Errors
-    class ParseError < StandardError; end
     class ParseTypeError < StandardError; end
   end
 end

--- a/lib/pubid/ieee/identifier/base.rb
+++ b/lib/pubid/ieee/identifier/base.rb
@@ -99,7 +99,7 @@ module Pubid::Ieee
         transform(parsed)
 
       rescue Parslet::ParseFailed => failure
-        raise Pubid::Ieee::Errors::ParseError, "#{failure.message}\ncause: #{failure.parse_failure_cause.ascii_tree}"
+        raise Pubid::Core::Errors::ParseError, "#{failure.message}\ncause: #{failure.parse_failure_cause.ascii_tree}"
       end
 
       def self.transform(params)

--- a/spec/pubid_ieee/identifiers_parsing_spec.rb
+++ b/spec/pubid_ieee/identifiers_parsing_spec.rb
@@ -1044,7 +1044,7 @@ module Pubid::Ieee
             expect do
               described_class.parse(pub_id)
             rescue Exception => failure
-              raise Pubid::Ieee::Errors::ParseError,
+              raise Pubid::Core::Errors::ParseError,
                     "couldn't parse #{pub_id}\n#{failure.message}"
             end.not_to raise_error
           end


### PR DESCRIPTION
related to https://github.com/metanorma/pubid/issues/1